### PR TITLE
fix(snap): changed snap version in setup.sh and install-snap-python.sh

### DIFF
--- a/install-snap-python.sh
+++ b/install-snap-python.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-wget https://snap.stanford.edu/snappy/release/snap-4.0.0-4.0-centos6.5-x64-py2.6.tar.gz
-tar zxvf snap-4.0.0-4.0-centos6.5-x64-py2.6.tar.gz
-cd snap-4.0.0-4.0-centos6.5-x64-py2.6
+wget https://snap.stanford.edu/snappy/release/snap-4.1.0-4.1-centos6.5-x64-py2.6.tar.gz
+tar zxvf snap-4.1.0-4.1-centos6.5-x64-py2.6.tar.gz
+cd snap-4.1.0-4.1-centos6.5-x64-py2.6
 sudo python setup.py install
 cp snap.py ../bellydynamic-travis/
 cp _snap.so ../bellydynamic-travis/

--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-wget https://snap.stanford.edu/snappy/release/snap-4.0.0-4.0-centos6.5-x64-py2.6.tar.gz;
-tar zxvf snap-4.0.0-4.0-centos6.5-x64-py2.6.tar.gz;
-cd snap-4.0.0-4.0-centos6.5-x64-py2.6;
+wget https://snap.stanford.edu/snappy/release/snap-4.1.0-4.1-centos6.5-x64-py2.6.tar.gz;
+tar zxvf snap-4.1.0-4.1-centos6.5-x64-py2.6.tar.gz;
+cd snap-4.1.0-4.1-centos6.5-x64-py2.6;
 sudo python setup.py install & cd ..;
-cp snap-4.0.0-4.0-centos6.5-x64-py2.6/snap.py ./bellydynamic-adv/;
-cp snap-4.0.0-4.0-centos6.5-x64-py2.6/_snap.so ./bellydynamic-adv/
+cp snap-4.1.0-4.1-centos6.5-x64-py2.6/snap.py ./bellydynamic-adv/;
+cp snap-4.1.0-4.1-centos6.5-x64-py2.6/_snap.so ./bellydynamic-adv/
 chmod +x ./bellydynamic-adv/snap.py;
 chmod +x ./bellydynamic-adv/_snap.so;
 


### PR DESCRIPTION
Changed snap version to remove 404 not found error on both scripts. Kudos to Kalyan3578 and everybody else who mentioned this issue, I am just making small change, they figured it out :+1:  . I don't think there are any possible breaking changes, but @charithccmc @agentmilindu review. Closes issues #29 #28 #25 #24 #22 